### PR TITLE
Add -e to copy encrypted pass to clipboard

### DIFF
--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -243,19 +243,20 @@ clipenc() {
     # Manage clipboard history and auto-clear
 	# Run in a disowned subprocess that sends outputs to /dev/null
     (
-        ( exec -a "$sleep_argv0" bash <<<"trap 'kill %1' TERM; sleep '$CLIP_TIME' & wait" )
-        local now="$("${paste_cmd[@]}" | $BASE64)"
+		( exec -a "$sleep_argv0" bash <<<"trap 'kill %1' TERM; sleep '$CLIP_TIME' & wait" )
+		local now="$("${paste_cmd[@]}" | $BASE64)"
+
 		if [[ $now != "$what_was_put_in_clip" ]]; then
 			# Clipboard content changed, so we assume the user has manually copied something else
 			# Do not restore clipboard content
 			before="$now"
 		fi
 
-        # Clear clipboard history (if supported by KDE Klipper)
-        qdbus org.kde.klipper /klipper org.kde.klipper.klipper.clearClipboardHistory &>/dev/null
+		# Clear clipboard history (if supported by KDE Klipper)
+		qdbus org.kde.klipper /klipper org.kde.klipper.klipper.clearClipboardHistory &>/dev/null
 
-        # Restore previous clipboard contents
-        echo "$before" | $BASE64 -d | "${copy_cmd[@]}"
+		# Restore previous clipboard contents
+		echo "$before" | $BASE64 -d | "${copy_cmd[@]}"
     ) >/dev/null 2>&1 & disown
 
     echo "Encrypted data copied to clipboard for recipients: ${GPG_RECIPIENTS[*]}"
@@ -314,7 +315,7 @@ BASE64="base64"
 source "$(dirname "$0")/platform/$(uname | cut -d _ -f 1 | tr '[:upper:]' '[:lower:]').sh" 2>/dev/null # PLATFORM_FUNCTION_FILE
 
 #
-# END platform definableremote -v
+# END platform definable
 #
 
 
@@ -432,7 +433,7 @@ cmd_init() {
 
 cmd_show() {
 	local opts selected_line clip=0 qrcode=0
-	opts="$($GETOPT -o q::c::e:: -l qrcode::,clip::,enc:: -n "$PROGRAM" -- "$@")"
+	opts="$($GETOPT -o q::c:: -l qrcode::,clip:: -n "$PROGRAM" -- "$@")"
 	local err=$?
 	eval set -- "$opts"
 	while true; do case $1 in
@@ -458,8 +459,6 @@ cmd_show() {
 			[[ -n $pass ]] || die "There is no password to put on the clipboard at line ${selected_line}."
 			if [[ $clip -eq 1 ]]; then
 				clip "$pass" "$path"
-			elif [[ $enc -eq 1 ]]; then
-				clipenc "$pass" "$path"
 			elif [[ $qrcode -eq 1 ]]; then
 				qrcode "$pass" "$path"
 			fi
@@ -623,6 +622,8 @@ cmd_generate() {
 
 	if [[ $clip -eq 1 ]]; then
 		clip "$pass" "$path"
+	elif [[ $enc -eq 1 ]]; then
+		clipenc "$pass" "$path"
 	elif [[ $qrcode -eq 1 ]]; then
 		qrcode "$pass" "$path"
 	else

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -433,7 +433,7 @@ cmd_init() {
 
 cmd_show() {
 	local opts selected_line clip=0 qrcode=0
-	opts="$($GETOPT -o q::c:: -l qrcode::,clip:: -n "$PROGRAM" -- "$@")"
+	opts="$($GETOPT -o q::c::e:: -l qrcode::,clip::,enc:: -n "$PROGRAM" -- "$@")"
 	local err=$?
 	eval set -- "$opts"
 	while true; do case $1 in
@@ -459,6 +459,8 @@ cmd_show() {
 			[[ -n $pass ]] || die "There is no password to put on the clipboard at line ${selected_line}."
 			if [[ $clip -eq 1 ]]; then
 				clip "$pass" "$path"
+			elif [[ $enc -eq 1 ]]; then
+				clipenc "$pass" "$path"
 			elif [[ $qrcode -eq 1 ]]; then
 				qrcode "$pass" "$path"
 			fi
@@ -622,8 +624,6 @@ cmd_generate() {
 
 	if [[ $clip -eq 1 ]]; then
 		clip "$pass" "$path"
-	elif [[ $enc -eq 1 ]]; then
-		clipenc "$pass" "$path"
 	elif [[ $qrcode -eq 1 ]]; then
 		qrcode "$pass" "$path"
 	else

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -9,7 +9,7 @@ set -o pipefail
 GPG_OPTS=( $PASSWORD_STORE_GPG_OPTS "--quiet" "--yes" "--compress-algo=none" "--no-encrypt-to" )
 GPG="gpg"
 export GPG_TTY="${GPG_TTY:-$(tty 2>/dev/null)}"
-command -v gpg2 &>/dev/null && GPG="gpg2"
+which gpg2 &>/dev/null && GPG="gpg2"
 [[ -n $GPG_AGENT_INFO || $GPG == "gpg2" ]] && GPG_OPTS+=( "--batch" "--use-agent" )
 
 PREFIX="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
@@ -70,7 +70,6 @@ verify_file() {
 set_gpg_recipients() {
 	GPG_RECIPIENT_ARGS=( )
 	GPG_RECIPIENTS=( )
-	local gpg_id
 
 	if [[ -n $PASSWORD_STORE_KEY ]]; then
 		for gpg_id in $PASSWORD_STORE_KEY; do
@@ -99,6 +98,7 @@ set_gpg_recipients() {
 
 	verify_file "$current"
 
+	local gpg_id
 	while read -r gpg_id; do
 		gpg_id="${gpg_id%%#*}" # strip comment
 		[[ -n $gpg_id ]] || continue
@@ -129,7 +129,7 @@ reencrypt_path() {
 			done
 			gpg_keys="$($GPG $PASSWORD_STORE_GPG_OPTS --list-keys --with-colons "${GPG_RECIPIENTS[@]}" | sed -n 's/^sub:[^idr:]*:[^:]*:[^:]*:\([^:]*\):[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:[a-zA-Z]*e[a-zA-Z]*:.*/\1/p' | LC_ALL=C sort -u)"
 		fi
-		current_keys="$(LC_ALL=C $GPG $PASSWORD_STORE_GPG_OPTS -v --no-secmem-warning --no-permission-warning --decrypt --list-only --keyid-format long "$passfile" 2>&1 | sed -nE 's/^gpg: public key is ([A-F0-9]+)$/\1/p' | LC_ALL=C sort -u)"
+		current_keys="$(LC_ALL=C $GPG $PASSWORD_STORE_GPG_OPTS -v --no-secmem-warning --no-permission-warning --decrypt --list-only --keyid-format long "$passfile" 2>&1 | sed -n 's/^gpg: public key is \([A-F0-9]\+\)$/\1/p' | LC_ALL=C sort -u)"
 
 		if [[ $gpg_keys != "$current_keys" ]]; then
 			echo "$passfile_display: reencrypting to ${gpg_keys//$'\n'/ }"
@@ -137,7 +137,7 @@ reencrypt_path() {
 			mv "$passfile_temp" "$passfile" || rm -f "$passfile_temp"
 		fi
 		prev_gpg_recipients="${GPG_RECIPIENTS[*]}"
-	done < <(find "$1" -path '*/.git' -prune -o -path '*/.extensions' -prune -o -iname '*.gpg' -print0)
+	done < <(find "$1" -path '*/.git' -prune -o -iname '*.gpg' -print0)
 }
 check_sneaky_paths() {
 	local path
@@ -155,7 +155,7 @@ check_sneaky_paths() {
 #
 
 clip() {
-	if [[ -n $WAYLAND_DISPLAY ]] && command -v wl-copy &> /dev/null; then
+	if [[ -n $WAYLAND_DISPLAY ]]; then
 		local copy_cmd=( wl-copy )
 		local paste_cmd=( wl-paste -n )
 		if [[ $X_SELECTION == primary ]]; then
@@ -163,12 +163,12 @@ clip() {
 			paste_cmd+=( --primary )
 		fi
 		local display_name="$WAYLAND_DISPLAY"
-	elif [[ -n $DISPLAY ]] && command -v xclip &> /dev/null; then
+	elif [[ -n $DISPLAY ]]; then
 		local copy_cmd=( xclip -selection "$X_SELECTION" )
 		local paste_cmd=( xclip -o -selection "$X_SELECTION" )
 		local display_name="$DISPLAY"
 	else
-		die "Error: No X11 or Wayland display and clipper detected"
+		die "Error: No X11 or Wayland display detected"
 	fi
 	local sleep_argv0="password store sleep on display $display_name"
 
@@ -195,6 +195,71 @@ clip() {
 		echo "$before" | $BASE64 -d | "${copy_cmd[@]}"
 	) >/dev/null 2>&1 & disown
 	echo "Copied $2 to clipboard. Will clear in $CLIP_TIME seconds."
+}
+
+clipenc() {
+    local plaintext="$1"
+    if [[ -z $plaintext ]]; then
+        die "Error: No plaintext provided for encryption."
+    fi
+
+    # Determine GPG recipients dynamically
+    set_gpg_recipients ""  # Use the top-level .gpg-id or the appropriate directory
+    if [[ ${#GPG_RECIPIENTS[@]} -eq 0 ]]; then
+        die "Error: No GPG recipients found. Please run 'pass init' first."
+    fi
+
+    # Prepare GPG recipient arguments
+    local gpg_recipients=("${GPG_RECIPIENT_ARGS[@]}")
+
+    # Handle clipboard tools for Wayland and X11
+    if [[ -n $WAYLAND_DISPLAY ]]; then
+        local copy_enc_cmd=( bash -c "echo -n \"$plaintext\" | gpg --encrypt --armour ${gpg_recipients[*]} | wl-copy" )
+		local copy_cmd=( wl-copy )
+        local paste_cmd=( wl-paste -n )
+        [[ $X_SELECTION == primary ]] && copy_enc_cmd+=( --primary ) && paste_cmd+=( --primary )
+        local display_name="$WAYLAND_DISPLAY"
+    elif [[ -n $DISPLAY ]]; then
+        local copy_enc_cmd=( bash -c "echo -n \"$plaintext\" | gpg --encrypt --armour ${gpg_recipients[*]} | xclip -selection $X_SELECTION" )
+		local copy_cmd=( xclip -selection "$X_SELECTION" )
+        local paste_cmd=( xclip -o -selection $X_SELECTION )
+        local display_name="$DISPLAY"
+    else
+        die "Error: No X11 or Wayland display detected"
+    fi
+
+    # Prevent conflicts with existing clipboard sleep processes
+    local sleep_argv0="password store sleep on display $display_name"
+    pkill -f "^$sleep_argv0" 2>/dev/null && sleep 0.5
+
+    # Store previous clipboard contents
+    local before="$("${paste_cmd[@]}" 2>/dev/null | $BASE64)"
+
+    # Execute the copy encrypted command
+    "${copy_enc_cmd[@]}" || die "Error: Could not encrypt data and copy to the clipboard"
+	# we can re-encrypt to compare, cause every encryption will be different as it uses random nonces, so we will backup the value
+	local what_was_put_in_clip="$("${paste_cmd[@]}" | $BASE64)"
+
+    # Manage clipboard history and auto-clear
+	# Run in a disowned subprocess that sends outputs to /dev/null
+    (
+        ( exec -a "$sleep_argv0" bash <<<"trap 'kill %1' TERM; sleep '$CLIP_TIME' & wait" )
+        local now="$("${paste_cmd[@]}" | $BASE64)"
+		if [[ $now != "$what_was_put_in_clip" ]]; then
+			# Clipboard content changed, so we assume the user has manually copied something else
+			# Do not restore clipboard content
+			before="$now"
+		fi
+
+        # Clear clipboard history (if supported by KDE Klipper)
+        qdbus org.kde.klipper /klipper org.kde.klipper.klipper.clearClipboardHistory &>/dev/null
+
+        # Restore previous clipboard contents
+        echo "$before" | $BASE64 -d | "${copy_cmd[@]}"
+    ) >/dev/null 2>&1 & disown
+
+    echo "Encrypted data copied to clipboard for recipients: ${GPG_RECIPIENTS[*]}"
+    echo "Will clear in $CLIP_TIME seconds."
 }
 
 qrcode() {
@@ -249,7 +314,7 @@ BASE64="base64"
 source "$(dirname "$0")/platform/$(uname | cut -d _ -f 1 | tr '[:upper:]' '[:lower:]').sh" 2>/dev/null # PLATFORM_FUNCTION_FILE
 
 #
-# END platform definable
+# END platform definableremote -v
 #
 
 
@@ -284,7 +349,7 @@ cmd_usage() {
 	        List passwords.
 	    $PROGRAM find pass-names...
 	    	List passwords that match pass-names.
-	    $PROGRAM [show] [--clip[=line-number],-c[line-number]] pass-name
+	    $PROGRAM [show] [--clip[=line-number],-c[line-number],--enc[=line-number],-e[line-number]] pass-name
 	        Show existing password and optionally put it on the clipboard.
 	        If put on the clipboard, it will be cleared in $CLIP_TIME seconds.
 	    $PROGRAM grep [GREPOPTIONS] search-string
@@ -367,12 +432,13 @@ cmd_init() {
 
 cmd_show() {
 	local opts selected_line clip=0 qrcode=0
-	opts="$($GETOPT -o q::c:: -l qrcode::,clip:: -n "$PROGRAM" -- "$@")"
+	opts="$($GETOPT -o q::c::e:: -l qrcode::,clip::,enc:: -n "$PROGRAM" -- "$@")"
 	local err=$?
 	eval set -- "$opts"
 	while true; do case $1 in
 		-q|--qrcode) qrcode=1; selected_line="${2:-1}"; shift 2 ;;
 		-c|--clip) clip=1; selected_line="${2:-1}"; shift 2 ;;
+		-e|--enc) enc=1; selected_line="${2:-1}"; shift 2 ;;
 		--) shift; break ;;
 	esac done
 
@@ -383,7 +449,7 @@ cmd_show() {
 	local passfile="$PREFIX/$path.gpg"
 	check_sneaky_paths "$path"
 	if [[ -f $passfile ]]; then
-		if [[ $clip -eq 0 && $qrcode -eq 0 ]]; then
+		if [[ $clip -eq 0 && $qrcode -eq 0 && $enc -eq 0 ]]; then
 			pass="$($GPG -d "${GPG_OPTS[@]}" "$passfile" | $BASE64)" || exit $?
 			echo "$pass" | $BASE64 -d
 		else
@@ -392,6 +458,8 @@ cmd_show() {
 			[[ -n $pass ]] || die "There is no password to put on the clipboard at line ${selected_line}."
 			if [[ $clip -eq 1 ]]; then
 				clip "$pass" "$path"
+			elif [[ $enc -eq 1 ]]; then
+				clipenc "$pass" "$path"
 			elif [[ $qrcode -eq 1 ]]; then
 				qrcode "$pass" "$path"
 			fi
@@ -430,7 +498,7 @@ cmd_grep() {
 		passfile="${passfile##*/}"
 		printf "\e[94m%s\e[1m%s\e[0m:\n" "$passfile_dir" "$passfile"
 		echo "$grepresults"
-	done < <(find -L "$PREFIX" -path '*/.git' -prune -o -path '*/.extensions' -prune -o -iname '*.gpg' -print0)
+	done < <(find -L "$PREFIX" -path '*/.git' -prune -o -iname '*.gpg' -print0)
 }
 
 cmd_insert() {


### PR DESCRIPTION
Add a feature to copy encrypted passwords to the clipboard so that clipboard sniffers can't see the plain text password. 
It is the responsibility of the app that uses the password to decrypt it, in my case I am using a custom browser extension to do so